### PR TITLE
chore: update @stencil/core to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "typescript": "^4.7.4"
       },
       "peerDependencies": {
-        "@stencil/core": "^2.9.0"
+        "@stencil/core": "^4.0.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -953,16 +953,16 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.17.1.tgz",
-      "integrity": "sha512-ErjQsNALgZQ9SYeBHhqwL1UO+Zbptwl3kwrRJC2tGlc3G/T6UvPuaKr+PGsqI+CZGia+0+R5EELQvFu74mYeIg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.0.3.tgz",
+      "integrity": "sha512-uWaH4tQ16So1feRu4tD0gupDEnzhRatS3Jp9uYkYlqjhx5BQ/ox5CTP+lxboochqkLlvkmXvhH9SsEV+UTsYTA==",
       "peer": true,
       "bin": {
         "stencil": "bin/stencil"
       },
       "engines": {
-        "node": ">=12.10.0",
-        "npm": ">=6.0.0"
+        "node": ">=16.0.0",
+        "npm": ">=7.10.0"
       }
     },
     "node_modules/@types/babel__core": {
@@ -4198,9 +4198,9 @@
       }
     },
     "@stencil/core": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.17.1.tgz",
-      "integrity": "sha512-ErjQsNALgZQ9SYeBHhqwL1UO+Zbptwl3kwrRJC2tGlc3G/T6UvPuaKr+PGsqI+CZGia+0+R5EELQvFu74mYeIg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.0.3.tgz",
+      "integrity": "sha512-uWaH4tQ16So1feRu4tD0gupDEnzhRatS3Jp9uYkYlqjhx5BQ/ox5CTP+lxboochqkLlvkmXvhH9SsEV+UTsYTA==",
       "peer": true
     },
     "@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "typescript": "^4.7.4"
   },
   "peerDependencies": {
-    "@stencil/core": "^2.9.0"
+    "@stencil/core": "^4.0.3"
   },
   "jest": {
     "transform": {


### PR DESCRIPTION
Fixes #7

To install this version:

```sh
npm install arthur-fontaine/stencil-solid-output-target#pull/9/head
```